### PR TITLE
Added `adc` library

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -9,6 +9,7 @@ filesystem:
 libs:
     # libs necessary for the current app
   - origin: https://github.com/mongoose-os-libs/mjs
+  - origin: https://github.com/mongoose-os-libs/adc  
 tags:
   - mq135
   - sensor


### PR DESCRIPTION
The library uses `adc` which is not included in `mos.yml`